### PR TITLE
Update fontconfig Build Dependency for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It is a workspace member but is **not compiled by default** (`default-members` e
 
 ```bash
 # Debian / Ubuntu
-sudo apt-get install libfontconfig1-dev
+sudo apt-get install libfontconfig-dev
 
 # Fedora / RHEL
 sudo dnf install fontconfig-devel


### PR DESCRIPTION
The 'libfontconfig1-dev' package has been a dummy transitional package to 'libfontconfig-dev' since at least Bullseye, which is (currently) oldoldstable, so update the build dependency to its target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Debian/Ubuntu setup instructions to use the correct Fontconfig development package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->