### PR TITLE
v4.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,7 +4144,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "torrust-actix"
-version = "4.2.17"
+version = "4.2.18"
 dependencies = [
  "actix",
  "actix-cors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 
 [package]
 name = "torrust-actix"
-version = "4.2.17"
+version = "4.2.18"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -107,7 +107,7 @@ harness = false
 name = "Torrust Actix"
 identifier = "com.power2all.torrust-actix"
 icon = ["icon.ico"]
-version = "4.2.17"
+version = "4.2.18"
 copyright = "Copyright (c) 2024-2026 Power2All"
 category = "Public Utility"
 short_description = "BitTorrent Tracker"

--- a/README.md
+++ b/README.md
@@ -52,15 +52,6 @@ cd torrust-actix
 cargo build --release
 ```
 
-> **Note:** `lib/torrust-client` (the optional desktop GUI) is **excluded from the default build**.
-> It requires the `fontconfig` system library and a graphical environment (Slint UI framework).
-> See [lib/torrust-client — Optional GUI](#optional-gui-torrust-client) below for details.
-
-### Optional GUI: torrust-client
-
-`lib/torrust-client` is a desktop GUI front-end built with the [Slint](https://slint.dev/) UI framework.
-It is a workspace member but is **not compiled by default** (`default-members` excludes it).
-
 #### System requirements (Linux)
 
 ```bash
@@ -77,11 +68,8 @@ sudo pacman -S fontconfig
 #### Building
 
 ```bash
-# Build only the GUI client
-cargo build --release -p torrust-client
-
-# Or build the entire workspace including the GUI
-cargo build --release --workspace
+# Build the project
+cargo build --release
 ```
 
 ### Usage
@@ -609,6 +597,9 @@ echo "WebRTC seeds:  {$data['rtc_seeds']}";
 ---
 
 ### ChangeLog
+
+#### v4.2.18
+* Bugfix: A database connection loss or error, could freeze and lock up the update thread, should be fixed now.
 
 #### v4.2.17
 * Full code auditing, and found some possible security issues in the future.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:alpine
 RUN apk update --no-interactive
 RUN apk add git musl-dev curl pkgconfig openssl-dev openssl-libs-static --no-interactive
 RUN git clone https://github.com/Power2All/torrust-actix.git /app/torrust-actix
-RUN cd /app/torrust-actix && git checkout tags/v4.2.17
+RUN cd /app/torrust-actix && git checkout tags/v4.2.18
 WORKDIR /app/torrust-actix
 RUN cd /app/torrust-actix
 RUN cargo build --release && rm -Rf target/release/.fingerprint target/release/build target/release/deps target/release/examples target/release/incremental

--- a/docker/build.bat
+++ b/docker/build.bat
@@ -1,5 +1,5 @@
 @echo off
 
-docker build --no-cache -t power2all/torrust-actix:v4.2.17 -t power2all/torrust-actix:latest .
-docker push power2all/torrust-actix:v4.2.17
+docker build --no-cache -t power2all/torrust-actix:v4.2.18 -t power2all/torrust-actix:latest .
+docker push power2all/torrust-actix:v4.2.18
 docker push power2all/torrust-actix:latest

--- a/src/cache/impls/cache_connector_cache_backend.rs
+++ b/src/cache/impls/cache_connector_cache_backend.rs
@@ -108,6 +108,26 @@ impl CacheBackend for CacheConnector {
         }
     }
 
+    async fn delete_torrents(&self, info_hashes: &[InfoHash]) -> Result<(), CacheError> {
+        match self.engine.as_ref() {
+            Some(CacheEngine::redis) => {
+                if let Some(ref redis) = self.redis {
+                    redis.delete_torrents(info_hashes).await
+                } else {
+                    Err(CacheError::ConnectionError("Redis not connected".to_string()))
+                }
+            }
+            Some(CacheEngine::memcache) => {
+                if let Some(ref memcache) = self.memcache {
+                    memcache.delete_torrents(info_hashes).await
+                } else {
+                    Err(CacheError::ConnectionError("Memcache not connected".to_string()))
+                }
+            }
+            None => Err(CacheError::ConnectionError("No cache engine configured".to_string())),
+        }
+    }
+
     async fn set_torrent_peers_batch(
         &self,
         data: &[(InfoHash, TorrentPeerCounts)],

--- a/src/cache/impls/cache_connector_redis_cache_backend.rs
+++ b/src/cache/impls/cache_connector_redis_cache_backend.rs
@@ -130,6 +130,19 @@ impl CacheBackend for CacheConnectorRedis {
         Ok(())
     }
 
+    async fn delete_torrents(&self, info_hashes: &[InfoHash]) -> Result<(), CacheError> {
+        if info_hashes.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn().await?;
+        let keys: Vec<String> = info_hashes.iter().map(|hash| self.torrent_key(hash)).collect();
+        conn.del::<_, ()>(keys)
+            .await
+            .map_err(CacheError::RedisError)?;
+        debug!("[Redis] Deleted {} torrents", info_hashes.len());
+        Ok(())
+    }
+
     async fn set_torrent_peers_batch(
         &self,
         data: &[(InfoHash, TorrentPeerCounts)],

--- a/src/cache/traits/cache_backend.rs
+++ b/src/cache/traits/cache_backend.rs
@@ -21,6 +21,15 @@ pub trait CacheBackend: Send + Sync {
 
     async fn delete_torrent(&self, info_hash: &InfoHash) -> Result<(), CacheError>;
 
+    /// Deletes several torrents at once. Backends that cannot do better fall back to
+    /// deleting one by one.
+    async fn delete_torrents(&self, info_hashes: &[InfoHash]) -> Result<(), CacheError> {
+        for info_hash in info_hashes {
+            self.delete_torrent(info_hash).await?;
+        }
+        Ok(())
+    }
+
     async fn set_torrent_peers_batch(
         &self,
         data: &[(InfoHash, TorrentPeerCounts)],

--- a/src/common/common.rs
+++ b/src/common/common.rs
@@ -216,7 +216,18 @@ pub fn setup_logging(config: &Configuration) {
             ));
         })
         .level(level)
-        .chain(std::io::stdout())
+        // ERROR goes to stderr, everything else to stdout, so `2>` / a supervisor's
+        // error stream captures only the failures.
+        .chain(
+            fern::Dispatch::new()
+                .filter(|metadata| metadata.level() == log::Level::Error)
+                .chain(std::io::stderr())
+        )
+        .chain(
+            fern::Dispatch::new()
+                .filter(|metadata| metadata.level() != log::Level::Error)
+                .chain(std::io::stdout())
+        )
         .apply()
         .unwrap_or_else(|_| panic!("Failed to initialize logging."));
     info!("logging initialized.");

--- a/src/database/impls/database_connector.rs
+++ b/src/database/impls/database_connector.rs
@@ -11,9 +11,59 @@ use crate::tracker::structs::torrent_update_data::TorrentUpdateData;
 use crate::tracker::structs::torrent_tracker::TorrentTracker;
 use crate::tracker::structs::user_entry_item::UserEntryItem;
 use crate::tracker::structs::user_id::UserId;
+use log::{
+    error,
+    warn
+};
 use sqlx::Error;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+
+/// True when the failure is about the connection rather than the statement.
+///
+/// `Error::Io` is what a pooled connection closed by the server surfaces as
+/// ("error communicating with database: peer closed connection without sending
+/// TLS close_notify"): MySQL/PostgreSQL can drop a connection at any point
+/// during a long batch — restart, `wait_timeout`, `KILL`, a proxy in between —
+/// and the pool only tests liveness at acquire time, not mid-transaction.
+/// Retrying such a failure gets a fresh connection; retrying a rejected
+/// statement would just fail identically, so those are not retried.
+fn is_transient(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::Io(_) | Error::Tls(_) | Error::Protocol(_) | Error::PoolTimedOut | Error::WorkerCrashed
+    )
+}
+
+/// Runs a database operation, retrying it once on a dropped connection.
+///
+/// Also the single place every failure is logged: the engine backends propagate
+/// `self.pool.begin()` and `commit_chunk()` failures with a bare `?`, so before
+/// this a flush could fail completely silently and the only trace was the
+/// caller's "Unable to sync N torrents".
+///
+/// Engine-agnostic on purpose — MySQL, PostgreSQL and SQLite all route through
+/// here, so none of them can take down its sync task with a connection error.
+///
+/// A macro rather than a function taking an async closure: the resulting future
+/// has to stay `Send` for `tokio::spawn`, and an `AsyncFnMut` bound is not
+/// higher-ranked enough over the closure's borrows for that to hold. The body is
+/// expanded twice, so anything it moves must be cloned per attempt.
+macro_rules! with_retry {
+    ($what:literal, $body:expr) => {
+        match $body {
+            Ok(value) => Ok(value),
+            Err(e) if is_transient(&e) => {
+                warn!("[DATABASE] {}: connection failed ({e}), retrying once on a fresh connection", $what);
+                $body.inspect_err(|e| error!("[DATABASE] {}: failed after retry: {e}", $what))
+            }
+            Err(e) => {
+                error!("[DATABASE] {}: failed: {e}", $what);
+                Err(e)
+            }
+        }
+    };
+}
 
 impl DatabaseConnector {
     /// Connects to the engine selected in the configuration (SQLite 3, MySQL or PostgreSQL),
@@ -36,30 +86,30 @@ impl DatabaseConnector {
     pub async fn load_torrents(&self, tracker: Arc<TorrentTracker>) -> Result<(u64, u64), Error>
     {
         let transaction = crate::utils::sentry_tracing::start_trace_transaction("db_load_torrents", "database");
-        let result: Result<(u64, u64), Error> = match self.engine.as_ref() {
+        let result: Result<(u64, u64), Error> = with_retry!("load_torrents", match self.engine.as_ref() {
             Some(DatabaseDrivers::sqlite3) => {
                 if let Some(ref sqlite) = self.sqlite {
-                    sqlite.load_torrents(tracker).await
+                    sqlite.load_torrents(tracker.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::mysql) => {
                 if let Some(ref mysql) = self.mysql {
-                    mysql.load_torrents(tracker).await
+                    mysql.load_torrents(tracker.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::pgsql) => {
                 if let Some(ref pgsql) = self.pgsql {
-                    pgsql.load_torrents(tracker).await
+                    pgsql.load_torrents(tracker.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             None => Err(Error::RowNotFound)
-        };
+        });
         if let Some(txn) = transaction {
             match &result {
                 Ok((loaded, completed)) => {
@@ -224,30 +274,30 @@ impl DatabaseConnector {
     /// `Error::RowNotFound` when no backend is initialised for the configured engine.
     pub async fn save_whitelist(&self, tracker: Arc<TorrentTracker>, whitelists: Vec<(InfoHash, UpdatesAction)>) -> Result<u64, Error>
     {
-        match self.engine.as_ref() {
+        with_retry!("save_whitelist", match self.engine.as_ref() {
             Some(DatabaseDrivers::sqlite3) => {
                 if let Some(ref sqlite) = self.sqlite {
-                    sqlite.save_whitelist(tracker, whitelists).await
+                    sqlite.save_whitelist(tracker.clone(), whitelists.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::mysql) => {
                 if let Some(ref mysql) = self.mysql {
-                    mysql.save_whitelist(tracker, whitelists).await
+                    mysql.save_whitelist(tracker.clone(), whitelists.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::pgsql) => {
                 if let Some(ref pgsql) = self.pgsql {
-                    pgsql.save_whitelist(tracker, whitelists).await
+                    pgsql.save_whitelist(tracker.clone(), whitelists.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             None => Err(Error::RowNotFound)
-        }
+        })
     }
 
     /// Persists blacklist additions/removals; returns the number of rows written.
@@ -258,30 +308,30 @@ impl DatabaseConnector {
     /// `Error::RowNotFound` when no backend is initialised for the configured engine.
     pub async fn save_blacklist(&self, tracker: Arc<TorrentTracker>, blacklists: Vec<(InfoHash, UpdatesAction)>) -> Result<u64, Error>
     {
-        match self.engine.as_ref() {
+        with_retry!("save_blacklist", match self.engine.as_ref() {
             Some(DatabaseDrivers::sqlite3) => {
                 if let Some(ref sqlite) = self.sqlite {
-                    sqlite.save_blacklist(tracker, blacklists).await
+                    sqlite.save_blacklist(tracker.clone(), blacklists.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::mysql) => {
                 if let Some(ref mysql) = self.mysql {
-                    mysql.save_blacklist(tracker, blacklists).await
+                    mysql.save_blacklist(tracker.clone(), blacklists.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::pgsql) => {
                 if let Some(ref pgsql) = self.pgsql {
-                    pgsql.save_blacklist(tracker, blacklists).await
+                    pgsql.save_blacklist(tracker.clone(), blacklists.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             None => Err(Error::RowNotFound)
-        }
+        })
     }
 
     /// Persists announce-key additions/removals with their expiry timestamps.
@@ -292,30 +342,30 @@ impl DatabaseConnector {
     /// `Error::RowNotFound` when no backend is initialised for the configured engine.
     pub async fn save_keys(&self, tracker: Arc<TorrentTracker>, keys: BTreeMap<InfoHash, (i64, UpdatesAction)>) -> Result<u64, Error>
     {
-        match self.engine.as_ref() {
+        with_retry!("save_keys", match self.engine.as_ref() {
             Some(DatabaseDrivers::sqlite3) => {
                 if let Some(ref sqlite) = self.sqlite {
-                    sqlite.save_keys(tracker, keys).await
+                    sqlite.save_keys(tracker.clone(), keys.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::mysql) => {
                 if let Some(ref mysql) = self.mysql {
-                    mysql.save_keys(tracker, keys).await
+                    mysql.save_keys(tracker.clone(), keys.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::pgsql) => {
                 if let Some(ref pgsql) = self.pgsql {
-                    pgsql.save_keys(tracker, keys).await
+                    pgsql.save_keys(tracker.clone(), keys.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             None => Err(Error::RowNotFound)
-        }
+        })
     }
 
     /// Persists a batch of torrent updates, committing in `chunk_size` chunks to keep
@@ -328,30 +378,30 @@ impl DatabaseConnector {
     pub async fn save_torrents(&self, tracker: Arc<TorrentTracker>, torrents: &BTreeMap<InfoHash, (TorrentUpdateData, UpdatesAction)>) -> Result<(), Error>
     {
         let transaction = crate::utils::sentry_tracing::start_trace_transaction("db_save_torrents", "database");
-        let result: Result<(), Error> = match self.engine.as_ref() {
+        let result: Result<(), Error> = with_retry!("save_torrents", match self.engine.as_ref() {
             Some(DatabaseDrivers::sqlite3) => {
                 if let Some(ref sqlite) = self.sqlite {
-                    sqlite.save_torrents(tracker, torrents).await
+                    sqlite.save_torrents(tracker.clone(), torrents).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::mysql) => {
                 if let Some(ref mysql) = self.mysql {
-                    mysql.save_torrents(tracker, torrents).await
+                    mysql.save_torrents(tracker.clone(), torrents).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::pgsql) => {
                 if let Some(ref pgsql) = self.pgsql {
-                    pgsql.save_torrents(tracker, torrents).await
+                    pgsql.save_torrents(tracker.clone(), torrents).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             None => Err(Error::RowNotFound)
-        };
+        });
         if let Some(txn) = transaction {
             match &result {
                 Ok(()) => {
@@ -380,30 +430,30 @@ impl DatabaseConnector {
     /// `Error::RowNotFound` when no backend is initialised for the configured engine.
     pub async fn save_users(&self, tracker: Arc<TorrentTracker>, users: BTreeMap<UserId, (UserEntryItem, UpdatesAction)>) -> Result<(), Error>
     {
-        match self.engine.as_ref() {
+        with_retry!("save_users", match self.engine.as_ref() {
             Some(DatabaseDrivers::sqlite3) => {
                 if let Some(ref sqlite) = self.sqlite {
-                    sqlite.save_users(tracker, users).await
+                    sqlite.save_users(tracker.clone(), users.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::mysql) => {
                 if let Some(ref mysql) = self.mysql {
-                    mysql.save_users(tracker, users).await
+                    mysql.save_users(tracker.clone(), users.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             Some(DatabaseDrivers::pgsql) => {
                 if let Some(ref pgsql) = self.pgsql {
-                    pgsql.save_users(tracker, users).await
+                    pgsql.save_users(tracker.clone(), users.clone()).await
                 } else {
                     Err(Error::RowNotFound)
                 }
             }
             None => Err(Error::RowNotFound)
-        }
+        })
     }
 
     /// Deletes all rows from the given table.
@@ -476,5 +526,30 @@ impl DatabaseConnector {
             }
             None => Err(Error::RowNotFound)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient;
+    use sqlx::Error;
+
+    /// A misclassification here is silent and costly either way: too narrow and a
+    /// dropped connection wastes a whole sync cycle, too wide and a permanently
+    /// rejected statement gets sent twice on every flush, forever.
+    #[test]
+    fn dropped_connections_retry_but_rejected_statements_do_not() {
+        // Exactly what the reported MySQL failure surfaces as.
+        assert!(is_transient(&Error::Io(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "peer closed connection without sending TLS close_notify",
+        ))));
+        assert!(is_transient(&Error::PoolTimedOut));
+        assert!(is_transient(&Error::Protocol("unexpected packet".into())));
+
+        // Retrying these would fail identically, so they must not be retried.
+        assert!(!is_transient(&Error::RowNotFound));
+        assert!(!is_transient(&Error::PoolClosed));
+        assert!(!is_transient(&Error::ColumnNotFound("info_hash".into())));
     }
 }

--- a/src/database/impls/database_connector_mysql.rs
+++ b/src/database/impls/database_connector_mysql.rs
@@ -338,7 +338,7 @@ impl DatabaseConnectorMySQL {
             if (handled as f64 / 1000f64).fract() == 0.0 || torrents.len() as u64 == handled {
                 info!("{LOG_PREFIX} Handled {handled} torrents");
             }
-            self.commit_chunk(&mut transaction, &mut in_chunk, chunk_size).await?;
+            transaction = self.commit_chunk(transaction, &mut in_chunk, chunk_size).await?;
         }
         info!("{LOG_PREFIX} Handled {handled} torrents");
         self.commit(transaction).await
@@ -848,7 +848,7 @@ impl DatabaseConnectorMySQL {
             if (handled as f64 / 1000f64).fract() == 0.0 || users.len() as u64 == handled {
                 info!("{LOG_PREFIX} Handled {handled} users");
             }
-            self.commit_chunk(&mut transaction, &mut in_chunk, chunk_size).await?;
+            transaction = self.commit_chunk(transaction, &mut in_chunk, chunk_size).await?;
         }
         info!("{LOG_PREFIX} Handled {handled} users");
         self.commit(transaction).await
@@ -874,18 +874,20 @@ impl DatabaseConnectorMySQL {
         Ok(())
     }
 
-    async fn commit_chunk(&self, transaction: &mut Transaction<'_, MySql>, in_chunk: &mut u64, chunk_size: u64) -> Result<(), Error> {
+    /// Commits and reopens the transaction every `chunk_size` rows.
+    ///
+    /// Commits the old transaction *before* opening the new one. The reverse
+    /// order held two pool connections at once, so a handful of concurrent sync
+    /// tasks could exhaust the pool and fail with an acquire timeout instead of
+    /// the real error.
+    async fn commit_chunk<'a>(&self, transaction: Transaction<'a, MySql>, in_chunk: &mut u64, chunk_size: u64) -> Result<Transaction<'a, MySql>, Error> {
         *in_chunk += 1;
-        if chunk_size != 0 && *in_chunk >= chunk_size {
-            let new_tx = self.pool.begin().await?;
-            let old_tx = std::mem::replace(transaction, new_tx);
-            if let Err(e) = old_tx.commit().await {
-                error!("{LOG_PREFIX} Error: {e}");
-                return Err(e);
-            }
-            *in_chunk = 0;
+        if chunk_size == 0 || *in_chunk < chunk_size {
+            return Ok(transaction);
         }
-        Ok(())
+        self.commit(transaction).await?;
+        *in_chunk = 0;
+        self.pool.begin().await.inspect_err(|e| error!("{LOG_PREFIX} Error: {e}"))
     }
 
     /// Commits the given transaction, logging and returning any failure.

--- a/src/database/impls/database_connector_pgsql.rs
+++ b/src/database/impls/database_connector_pgsql.rs
@@ -336,7 +336,7 @@ impl DatabaseConnectorPgSQL {
             if (handled as f64 / 1000f64).fract() == 0.0 || torrents.len() as u64 == handled {
                 info!("{LOG_PREFIX} Handled {handled} torrents");
             }
-            self.commit_chunk(&mut transaction, &mut in_chunk, chunk_size).await?;
+            transaction = self.commit_chunk(transaction, &mut in_chunk, chunk_size).await?;
         }
         info!("{LOG_PREFIX} Handled {handled} torrents");
         self.commit(transaction).await
@@ -856,7 +856,7 @@ impl DatabaseConnectorPgSQL {
             if (handled as f64 / 1000f64).fract() == 0.0 || users.len() as u64 == handled {
                 info!("{LOG_PREFIX} Handled {handled} users");
             }
-            self.commit_chunk(&mut transaction, &mut in_chunk, chunk_size).await?;
+            transaction = self.commit_chunk(transaction, &mut in_chunk, chunk_size).await?;
         }
         info!("{LOG_PREFIX} Handled {handled} users");
         self.commit(transaction).await
@@ -882,18 +882,20 @@ impl DatabaseConnectorPgSQL {
         Ok(())
     }
 
-    async fn commit_chunk(&self, transaction: &mut Transaction<'_, Postgres>, in_chunk: &mut u64, chunk_size: u64) -> Result<(), Error> {
+    /// Commits and reopens the transaction every `chunk_size` rows.
+    ///
+    /// Commits the old transaction *before* opening the new one. The reverse
+    /// order held two pool connections at once, so a handful of concurrent sync
+    /// tasks could exhaust the pool and fail with an acquire timeout instead of
+    /// the real error.
+    async fn commit_chunk<'a>(&self, transaction: Transaction<'a, Postgres>, in_chunk: &mut u64, chunk_size: u64) -> Result<Transaction<'a, Postgres>, Error> {
         *in_chunk += 1;
-        if chunk_size != 0 && *in_chunk >= chunk_size {
-            let new_tx = self.pool.begin().await?;
-            let old_tx = std::mem::replace(transaction, new_tx);
-            if let Err(e) = old_tx.commit().await {
-                error!("{LOG_PREFIX} Error: {e}");
-                return Err(e);
-            }
-            *in_chunk = 0;
+        if chunk_size == 0 || *in_chunk < chunk_size {
+            return Ok(transaction);
         }
-        Ok(())
+        self.commit(transaction).await?;
+        *in_chunk = 0;
+        self.pool.begin().await.inspect_err(|e| error!("{LOG_PREFIX} Error: {e}"))
     }
 
     /// Commits the given transaction, logging and returning any failure.

--- a/src/database/impls/database_connector_sqlite.rs
+++ b/src/database/impls/database_connector_sqlite.rs
@@ -359,7 +359,7 @@ impl DatabaseConnectorSQLite {
             if (handled as f64 / 1000f64).fract() == 0.0 || torrents.len() as u64 == handled {
                 info!("{LOG_PREFIX} Handled {handled} torrents");
             }
-            self.commit_chunk(&mut transaction_db, &mut in_chunk, chunk_size).await?;
+            transaction_db = self.commit_chunk(transaction_db, &mut in_chunk, chunk_size).await?;
         }
         info!("{LOG_PREFIX} Handled {handled} torrents");
         if let Some(txn) = transaction {
@@ -873,7 +873,7 @@ impl DatabaseConnectorSQLite {
             if (handled as f64 / 1000f64).fract() == 0.0 || users.len() as u64 == handled {
                 info!("{LOG_PREFIX} Handled {handled} users");
             }
-            self.commit_chunk(&mut transaction, &mut in_chunk, chunk_size).await?;
+            transaction = self.commit_chunk(transaction, &mut in_chunk, chunk_size).await?;
         }
         info!("{LOG_PREFIX} Handled {handled} users");
         self.commit(transaction).await
@@ -899,18 +899,20 @@ impl DatabaseConnectorSQLite {
         Ok(())
     }
 
-    async fn commit_chunk(&self, transaction: &mut Transaction<'_, Sqlite>, in_chunk: &mut u64, chunk_size: u64) -> Result<(), Error> {
+    /// Commits and reopens the transaction every `chunk_size` rows.
+    ///
+    /// Commits the old transaction *before* opening the new one. The reverse
+    /// order held two pool connections at once, so a handful of concurrent sync
+    /// tasks could exhaust the pool and fail with an acquire timeout instead of
+    /// the real error.
+    async fn commit_chunk<'a>(&self, transaction: Transaction<'a, Sqlite>, in_chunk: &mut u64, chunk_size: u64) -> Result<Transaction<'a, Sqlite>, Error> {
         *in_chunk += 1;
-        if chunk_size != 0 && *in_chunk >= chunk_size {
-            let new_tx = self.pool.begin().await?;
-            let old_tx = std::mem::replace(transaction, new_tx);
-            if let Err(e) = old_tx.commit().await {
-                error!("{LOG_PREFIX} Error: {e}");
-                return Err(e);
-            }
-            *in_chunk = 0;
+        if chunk_size == 0 || *in_chunk < chunk_size {
+            return Ok(transaction);
         }
-        Ok(())
+        self.commit(transaction).await?;
+        *in_chunk = 0;
+        self.pool.begin().await.inspect_err(|e| error!("{LOG_PREFIX} Error: {e}"))
     }
 
     /// Commits the given transaction, logging and returning any failure.

--- a/src/tracker/impls/torrent_tracker_torrents.rs
+++ b/src/tracker/impls/torrent_tracker_torrents.rs
@@ -16,8 +16,12 @@ impl TorrentTracker {
     /// Loads all torrents (and their completion counts) from the configured database at startup.
     pub async fn load_torrents(&self, tracker: Arc<TorrentTracker>)
     {
-        if let Ok((torrents, completes)) = self.sqlx.load_torrents(tracker).await {
-            info!("Loaded {torrents} torrents with {completes} completes");
+        match self.sqlx.load_torrents(tracker).await {
+            Ok((torrents, completes)) => info!("Loaded {torrents} torrents with {completes} completes"),
+            // Used to be swallowed silently, which is the worst possible outcome:
+            // the tracker comes up believing the database is empty and the next
+            // flush writes those empty counts back over the real rows.
+            Err(e) => error!("[LOAD TORRENTS] Unable to load torrents from the database: {e}"),
         }
     }
 

--- a/src/tracker/impls/torrent_tracker_torrents_updates.rs
+++ b/src/tracker/impls/torrent_tracker_torrents_updates.rs
@@ -138,12 +138,15 @@ impl TorrentTracker {
                     }
                 }
             }
-            for (hash, (_, action)) in &torrents_to_save {
-                if *action == UpdatesAction::Remove
-                    && let Err(e) = cache.delete_torrent(hash).await {
-                        warn!("[Cache] Failed to delete torrent {hash}: {e}");
-                    }
-            }
+            let removals: Vec<InfoHash> = torrents_to_save
+                .iter()
+                .filter(|(_, (_, action))| *action == UpdatesAction::Remove)
+                .map(|(hash, _)| *hash)
+                .collect();
+            if !removals.is_empty()
+                && let Err(e) = cache.delete_torrents(&removals).await {
+                    warn!("[Cache] Failed to delete {} torrents: {e}", removals.len());
+                }
         }
         if let Ok(()) = db_result {
             if is_persistent {

--- a/src/tracker/impls/torrent_tracker_torrents_updates.rs
+++ b/src/tracker/impls/torrent_tracker_torrents_updates.rs
@@ -102,50 +102,56 @@ impl TorrentTracker {
         } else {
             Ok(())
         };
+        // The cache flush is deliberately *not* gated on `db_result`: the two are
+        // independent sinks, and while the database was unreachable this used to
+        // stop refreshing the peer counts in Redis/memcache as well, so scrapes
+        // served stale numbers for as long as the outage lasted. Writing absolute
+        // counts is idempotent, so a batch the database rejected and re-queued
+        // simply gets written to the cache again on the next flush.
+        if let Some(ref cache) = self.cache {
+            let cache_ttl = self.config.cache.as_ref().and_then(|c| {
+                if c.ttl > 0 { Some(c.ttl) } else { None }
+            });
+            let cache_data: Vec<(InfoHash, TorrentPeerCounts)> = torrents_to_save
+                .iter()
+                .filter(|(_, (_, action))| *action != UpdatesAction::Remove)
+                .map(|(hash, (entry, _))| {
+                    let counts = TorrentPeerCounts {
+                        bt_seeds_ipv4: entry.seeds_ipv4,
+                        bt_seeds_ipv6: entry.seeds_ipv6,
+                        rtc_seeds:     entry.rtc_seeds,
+                        bt_peers_ipv4: entry.peers_ipv4,
+                        bt_peers_ipv6: entry.peers_ipv6,
+                        rtc_peers:     entry.rtc_peers,
+                        completed:     entry.completed,
+                    };
+                    (*hash, counts)
+                })
+                .collect();
+            if !cache_data.is_empty() {
+                match cache.set_torrent_peers_batch(&cache_data, cache_ttl).await {
+                    Ok(()) => {
+                        debug!("[Cache] Updated {} torrent peer counts", cache_data.len());
+                    }
+                    Err(e) => {
+                        warn!("[Cache] Failed to update peer counts: {e}");
+                    }
+                }
+            }
+            for (hash, (_, action)) in &torrents_to_save {
+                if *action == UpdatesAction::Remove
+                    && let Err(e) = cache.delete_torrent(hash).await {
+                        warn!("[Cache] Failed to delete torrent {hash}: {e}");
+                    }
+            }
+        }
         if let Ok(()) = db_result {
             if is_persistent {
                 info!("[SYNC TORRENT UPDATES] Synced {mapping_len} torrents");
             }
-            if let Some(ref cache) = self.cache {
-                let cache_ttl = self.config.cache.as_ref().and_then(|c| {
-                    if c.ttl > 0 { Some(c.ttl) } else { None }
-                });
-                let cache_data: Vec<(InfoHash, TorrentPeerCounts)> = torrents_to_save
-                    .iter()
-                    .filter(|(_, (_, action))| *action != UpdatesAction::Remove)
-                    .map(|(hash, (entry, _))| {
-                        let counts = TorrentPeerCounts {
-                            bt_seeds_ipv4: entry.seeds_ipv4,
-                            bt_seeds_ipv6: entry.seeds_ipv6,
-                            rtc_seeds:     entry.rtc_seeds,
-                            bt_peers_ipv4: entry.peers_ipv4,
-                            bt_peers_ipv6: entry.peers_ipv6,
-                            rtc_peers:     entry.rtc_peers,
-                            completed:     entry.completed,
-                        };
-                        (*hash, counts)
-                    })
-                    .collect();
-                if !cache_data.is_empty() {
-                    match cache.set_torrent_peers_batch(&cache_data, cache_ttl).await {
-                        Ok(()) => {
-                            debug!("[Cache] Updated {} torrent peer counts", cache_data.len());
-                        }
-                        Err(e) => {
-                            warn!("[Cache] Failed to update peer counts: {e}");
-                        }
-                    }
-                }
-                for (hash, (_, action)) in &torrents_to_save {
-                    if *action == UpdatesAction::Remove
-                        && let Err(e) = cache.delete_torrent(hash).await {
-                            warn!("[Cache] Failed to delete torrent {hash}: {e}");
-                        }
-                }
-            }
             Ok(())
         } else {
-            error!("[SYNC TORRENT UPDATES] Unable to sync {mapping_len} torrents");
+            error!("[SYNC TORRENT UPDATES] Unable to sync {mapping_len} torrents, re-queued for the next flush");
             let restored = self.torrents_updates.restore(drained_updates);
             self.update_stats(StatsEvent::TorrentsUpdates, restored);
             Err(())


### PR DESCRIPTION
Bugfix: When connection with DB has a problem, it could literally panic the thread (or freeze), this should prevent it from freezing and locking up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added retry for transient database connection/timeouts to reduce update freezes.
  - Improved batched transaction handling across MySQL/PostgreSQL/SQLite.
  - Added explicit error reporting when torrent loading fails.
  - Preserved drained peer-count cache writes/deletions and re-queues drained updates when flush fails.
- **Improvements**
  - Split error output from standard logs for clearer diagnostics.
  - Released version **4.2.18** and updated build/Docker image references.
- **Documentation**
  - Updated install/build instructions and added the **v4.2.18** changelog note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->